### PR TITLE
Update check.mjs [bug-fix]

### DIFF
--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -29,7 +29,7 @@ const CLASH_MAP = {
 
 /* ======= clash meta ======= */
 const META_URL_PREFIX = `https://github.com/MetaCubeX/Clash.Meta/releases/download/`;
-const META_VERSION = "v1.14.3";
+const META_VERSION = "v1.14.4";
 
 const META_MAP = {
   "win32-x64": "Clash.Meta-windows-amd64-compatible",


### PR DESCRIPTION
current version of clash.meta used in project has a verified bug in recognizing MacBooks with apple silicon chip.
as [this](https://github.com/hiddify/HiddifyClashDesktop/issues/18#issue-1686303948) report, changing the version v1.14.4 will fix it.

tested in Macs with both apple and intel cpus.